### PR TITLE
Fix install script for latest Arch version

### DIFF
--- a/archlinux.sh
+++ b/archlinux.sh
@@ -128,8 +128,8 @@ pacman -Syy --needed --noconfirm \
         iw networkmanager network-manager-applet \
         lightdm lightdm-gtk-greeter \
         chromium \
-        xorg-server xorg-server-utils xorg-apps xf86-input-synaptics \
-        xorg-twm xorg-xclock xterm xorg-xinit xorg-utils
+        xorg-server xorg-apps xf86-input-synaptics \
+        xorg-twm xorg-xclock xterm xorg-xinit
 systemctl enable NetworkManager
 systemctl enable lightdm
 EOF

--- a/archlinux.sh
+++ b/archlinux.sh
@@ -170,7 +170,7 @@ done
 
 yes | pacman --needed -U  \${packages[@]}
 
-sed -i 's/#IgnorePkg   =/IgnorePkg   = xorg-server xorg-server-common xf86-input-evdev xf86-input-synaptics/' /etc/pacman.conf
+sed -i 's/#IgnorePkg   =/IgnorePkg   = xorg-server xorg-server-common xorg-server-xvfb xf86-input-mouse xf86-input-keyboard xf86-input-evdev xf86-input-joystick xf86-input-synaptics xf86-video-fbdev/' /etc/pacman.conf
 
 EOF
 


### PR DESCRIPTION
Fixed error in install script: removed xorg-server-utils and xorg-util packages. These meta-packages were removed, xorg-apps is enough.
Fixed conflict during system upgrade: added all downgraded packages to IgnorePkgs.